### PR TITLE
FIX: mimic django rest framework default behaviour on None

### DIFF
--- a/drf_orjson_renderer/renderers.py
+++ b/drf_orjson_renderer/renderers.py
@@ -68,6 +68,9 @@ class ORJSONRenderer(BaseRenderer):
                 the following keys: view, request, response, args, kwargs
         :return: bytes() representation of the data encoded to UTF-8
         """
+        if data is None:
+            return b''
+
         renderer_context = renderer_context or {}
 
         # By default, this function will use its own version of `default()` in

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -357,6 +357,18 @@ class RendererTestCase(unittest.TestCase):
 
         self.assertEqual(reloaded, data)
 
+    def test_built_in_renderer_works_correctly_with_none(self):
+        """
+        Ensure that empty response won't generate 'null' as result.
+        """
+        data = None
+        rendered = self.renderer.render(
+            data=data,
+            media_type="application/json",
+        )
+
+        self.assertEqual(b'', rendered)
+
 
 class ParserTestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This Pull request fixes: https://github.com/brianjbuck/drf_orjson_renderer/issues/8

Empty reply (like http 204 status code) caused wrong behaviour, generating issues with some strict proxies.

It serialized None as 'null', causing header Content-Length to equal 4, but at the same time returning an empty body at django level.