### PR TITLE
Resolve #4 copy Django serialization for handling Promises

### DIFF
--- a/drf_orjson_renderer/renderers.py
+++ b/drf_orjson_renderer/renderers.py
@@ -5,6 +5,7 @@ import uuid
 from decimal import Decimal
 
 from django.core.serializers.json import DjangoJSONEncoder
+from django.utils.functional import Promise
 from rest_framework.renderers import BaseRenderer
 from rest_framework.settings import api_settings
 
@@ -49,7 +50,7 @@ class ORJSONRenderer(BaseRenderer):
                 return str(obj)
             else:
                 return float(obj)
-        elif isinstance(obj, (str, uuid.UUID)):
+        elif isinstance(obj, (str, uuid.UUID, Promise)):
             return str(obj)
         elif hasattr(obj, "tolist"):
             return obj.tolist()

--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,6 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )


### PR DESCRIPTION
```
(venv) cblakkan@Corlenis-MacBook-Air drf_orjson_renderer % git --no-pager log --oneline -n 2
fc1e8bf (HEAD -> feature/fix-promise, origin/feature/fix-promise) Fixes #4 copy DjangoJSONEncoder serialization for handling Promises
15fcfb6 (origin/master, origin/HEAD, master) Bump version to 1.1.5
(venv) cblakkan@Corlenis-MacBook-Air drf_orjson_renderer % pytest -v tests/tests.py
============================================================= test session starts =============================================================
platform darwin -- Python 3.9.9, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /Users/cblakkan/git/drf_orjson_renderer/venv/bin/python3.9
cachedir: .pytest_cache
rootdir: /Users/cblakkan/git/drf_orjson_renderer
plugins: cov-3.0.0
collected 28 items

tests/tests.py::RendererTestCase::test_basic_data_structures_rendered_correctly PASSED                                                  [  3%]
tests/tests.py::RendererTestCase::test_built_in_renderer_works_correctly_with_none PASSED                                               [  7%]
tests/tests.py::RendererTestCase::test_built_in_renderer_works_correctly_with_numpy_floating PASSED                                     [ 10%]
tests/tests.py::RendererTestCase::test_built_in_renderer_works_correctly_with_numpy_int PASSED                                          [ 14%]
tests/tests.py::RendererTestCase::test_renderer_works_correctly_when_media_type_and_context_provided PASSED                             [ 17%]
tests/tests.py::RendererTestCase::test_renderer_works_correctly_with_application_json PASSED                                            [ 21%]
tests/tests.py::RendererTestCase::test_renderer_works_correctly_with_browsable_api PASSED                                               [ 25%]
tests/tests.py::RendererTestCase::test_renderer_works_correctly_with_browsable_api_with_date PASSED                                     [ 28%]
tests/tests.py::RendererTestCase::test_renderer_works_correctly_with_browsable_api_with_datetime PASSED                                 [ 32%]
tests/tests.py::RendererTestCase::test_renderer_works_correctly_with_decimal_as_float PASSED                                            [ 35%]
tests/tests.py::RendererTestCase::test_renderer_works_correctly_with_decimal_as_str PASSED                                              [ 39%]
tests/tests.py::RendererTestCase::test_renderer_works_correctly_with_default_dict PASSED                                                [ 42%]
tests/tests.py::RendererTestCase::test_renderer_works_correctly_with_django_promise PASSED                                              [ 46%]
tests/tests.py::RendererTestCase::test_renderer_works_correctly_with_error_detail PASSED                                                [ 50%]
tests/tests.py::RendererTestCase::test_renderer_works_correctly_with_iter PASSED                                                        [ 53%]
tests/tests.py::RendererTestCase::test_renderer_works_correctly_with_numpy_array PASSED                                                 [ 57%]
tests/tests.py::RendererTestCase::test_renderer_works_correctly_with_numpy_floating PASSED                                              [ 60%]
tests/tests.py::RendererTestCase::test_renderer_works_correctly_with_numpy_int PASSED                                                   [ 64%]
tests/tests.py::RendererTestCase::test_renderer_works_correctly_with_ordered_dict PASSED                                                [ 67%]
tests/tests.py::RendererTestCase::test_renderer_works_correctly_with_return_dict PASSED                                                 [ 71%]
tests/tests.py::RendererTestCase::test_renderer_works_correctly_with_return_list PASSED                                                 [ 75%]
tests/tests.py::RendererTestCase::test_renderer_works_correctly_with_uuid PASSED                                                        [ 78%]
tests/tests.py::RendererTestCase::test_renderer_works_with_provided_default PASSED                                                      [ 82%]
tests/tests.py::RendererTestCase::test_renderer_works_with_provided_default_is_none PASSED                                              [ 85%]
tests/tests.py::RendererTestCase::test_renderer_works_with_provided_default_is_none_raises_error PASSED                                 [ 89%]
tests/tests.py::ParserTestCase::test_basic_data_structures_parsed_correctly PASSED                                                      [ 92%]
tests/tests.py::ParserTestCase::test_parser_raises_decode_error PASSED                                                                  [ 96%]
tests/tests.py::ParserTestCase::test_parser_works_correctly_when_media_type_and_context_provided PASSED                                 [100%]

============================================================= 28 passed in 0.53s ==============================================================
(venv) cblakkan@Corlenis-MacBook-Air drf_orjson_renderer % pip list
Package                           Version
--------------------------------- ----------
appnope                           0.1.2
asgiref                           3.4.1
attrs                             21.2.0
backcall                          0.2.0
backports.entry-points-selectable 1.1.1
black                             21.11b1
cfgv                              3.3.1
click                             8.0.3
coverage                          6.2
decorator                         5.1.0
distlib                           0.3.3
Django                            3.2.9
djangorestframework               3.12.4
filelock                          3.4.0
identify                          2.4.0
iniconfig                         1.1.1
ipdb                              0.13.9
ipython                           7.30.0
isort                             5.10.1
jedi                              0.18.1
matplotlib-inline                 0.1.3
mypy-extensions                   0.4.3
nodeenv                           1.6.0
numpy                             1.17.3
orjson                            3.6.4
packaging                         21.3
parso                             0.8.2
pathspec                          0.9.0
pexpect                           4.8.0
pickleshare                       0.7.5
pip                               21.3.1
platformdirs                      2.4.0
pluggy                            1.0.0
pre-commit                        2.15.0
prompt-toolkit                    3.0.23
ptyprocess                        0.7.0
py                                1.11.0
Pygments                          2.10.0
pyparsing                         3.0.6
pytest                            6.2.5
pytest-cov                        3.0.0
pytest-cover                      3.0.0
pytest-coverage                   0.0
pytz                              2021.3
PyYAML                            6.0
regex                             2021.11.10
setuptools                        59.0.1
six                               1.16.0
sqlparse                          0.4.2
toml                              0.10.2
tomli                             1.2.2
traitlets                         5.1.1
typing_extensions                 4.0.0
virtualenv                        20.10.0
wcwidth                           0.2.5
```