### PR TITLE
Restore renderer's media_type

### DIFF
--- a/drf_orjson_renderer/renderers.py
+++ b/drf_orjson_renderer/renderers.py
@@ -22,6 +22,7 @@ class ORJSONRenderer(BaseRenderer):
     format: str = "json"
     html_media_type: str = "text/html"
     json_media_type: str = "application/json"
+    media_type: str = json_media_type
 
     options = functools.reduce(
         operator.or_,

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -75,6 +75,9 @@ class RendererTestCase(unittest.TestCase):
             "e": {"foo": "bar"},
         }
 
+    def test_default_media_type(self):
+        assert self.renderer.media_type == "application/json"
+
     def test_basic_data_structures_rendered_correctly(self):
 
         rendered = self.renderer.render(self.data)


### PR DESCRIPTION
Fix #11


DRF negotiation code requires `media_type` attribute to be str, but it's `None`.
https://github.com/encode/django-rest-framework/blob/380ac8e79dd85e6798eb00a730b7d4c4c4a86ebd/rest_framework/negotiation.py#L65-L69
