### PR TITLE
Pin django version to "<=4.1"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
-Django>=2.2,<=4.0
+Django>=2.2,<=4.1
 djangorestframework>=3.9
 orjson>=2.4


### PR DESCRIPTION
"Django<=4.0" is very strict rule, 4.0.1 and other minor versions are not satisfied this requirement.
