### PR TITLE
Use DRF default JSONEncoder

### DIFF
--- a/drf_orjson_renderer/renderers.py
+++ b/drf_orjson_renderer/renderers.py
@@ -1,13 +1,11 @@
 import functools
 import operator
-import uuid
-from decimal import Decimal
 from typing import Any, Optional
 
 import orjson
-from django.utils.functional import Promise
 from rest_framework.renderers import BaseRenderer
 from rest_framework.settings import api_settings
+from rest_framework.utils.encoders import JSONEncoder
 
 
 __all__ = ["ORJSONRenderer"]
@@ -29,33 +27,6 @@ class ORJSONRenderer(BaseRenderer):
         api_settings.user_settings.get("ORJSON_RENDERER_OPTIONS", ()),
         orjson.OPT_SERIALIZE_NUMPY,
     )
-
-    @staticmethod
-    def default(obj: Any) -> Any:
-        """
-        When orjson doesn't recognize an object type for serialization it passes
-        that object to this function which then converts the object to its
-        native Python equivalent.
-
-        :param obj: Object of any type to be converted.
-        :return: native python object
-        """
-
-        if isinstance(obj, dict):
-            return dict(obj)
-        elif isinstance(obj, list):
-            return list(obj)
-        elif isinstance(obj, Decimal):
-            if api_settings.COERCE_DECIMAL_TO_STRING:
-                return str(obj)
-            else:
-                return float(obj)
-        elif isinstance(obj, (str, uuid.UUID, Promise)):
-            return str(obj)
-        elif hasattr(obj, "tolist"):
-            return obj.tolist()
-        elif hasattr(obj, "__iter__"):
-            return list(item for item in obj)
 
     def render(
         self,
@@ -94,7 +65,7 @@ class ORJSONRenderer(BaseRenderer):
         # Don't do that here because you will lose the ability to pass `None`
         # to ORJSON.
         if "default_function" not in renderer_context:
-            default = self.default
+            default = JSONEncoder().default
         else:
             default = renderer_context["default_function"]
 

--- a/drf_orjson_renderer/renderers.py
+++ b/drf_orjson_renderer/renderers.py
@@ -21,6 +21,7 @@ class ORJSONRenderer(BaseRenderer):
     html_media_type: str = "text/html"
     json_media_type: str = "application/json"
     media_type: str = json_media_type
+    encoder_class = JSONEncoder
 
     options = functools.reduce(
         operator.or_,
@@ -65,7 +66,7 @@ class ORJSONRenderer(BaseRenderer):
         # Don't do that here because you will lose the ability to pass `None`
         # to ORJSON.
         if "default_function" not in renderer_context:
-            default = JSONEncoder().default
+            default = self.encoder_class().default
         else:
             default = renderer_context["default_function"]
 

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -38,21 +38,24 @@ class ToListObj:
         return [1]
 
 
-UUID_PARAM = uuid.uuid4()
 string_doubler = lazy(lambda i: i + i, str)
 
 DATA_PARAMS = [
-    (OrderedDict({"a": "b"}), {"a": "b"}, False),
-    (ListLikeObj([1]), [1], False),
-    (Decimal("1.0"), "1.0", True),
-    (Decimal("1.0"), 1.0, False),
-    ("Test", "Test", False),
-    (UUID_PARAM, str(UUID_PARAM), False),
-    (string_doubler("hello"), "hellohello", False),  # Promise
-    (ToListObj(), [1], False),
-    (IterObj(1), [1], False),
-    (ReturnList([{"1": 1}], serializer=None), [{"1": 1}], False),
-    (ReturnDict({"a": "b"}, serializer=None), {"a": "b"}, False),
+    (OrderedDict({"a": "b"}), b'{"a":"b"}', False),
+    (ListLikeObj([1]), b"[1]", False),
+    (Decimal("1.0"), b"1.0", True),
+    (Decimal("1.0"), b"1.0", False),
+    ("Test", b'"Test"', False),
+    (
+        uuid.UUID("3d7b1c0e-e83b-40bc-96ef-bf6c95f3cb7c"),
+        b'"3d7b1c0e-e83b-40bc-96ef-bf6c95f3cb7c"',
+        False,
+    ),
+    (string_doubler("hello"), b'"hellohello"', False),  # Promise
+    (ToListObj(), b"[1]", False),
+    (IterObj(1), b"[1]", False),
+    (ReturnList([{"1": 1}], serializer=None), b'[{"1":1}]', False),
+    (ReturnDict({"a": "b"}, serializer=None), b'{"a":"b"}', False),
 ]
 
 
@@ -60,7 +63,7 @@ DATA_PARAMS = [
 def test_built_in_default_method(test_input, expected, coerce_decimal):
     """Ensure that the built-in default method works for all data types."""
     api_settings.COERCE_DECIMAL_TO_STRING = True if coerce_decimal else False
-    result = ORJSONRenderer.default(test_input)
+    result = ORJSONRenderer().render(test_input)
     assert result == expected
 
 


### PR DESCRIPTION
The rest framework has already a default JSON encoder, it is better to use it to allow for simplier integration.