### PR TITLE
Remove upper limit on pinned django version, only keep Django>=3.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
-Django>=2.2,<=4.0
+Django>=3.2
 djangorestframework>=3.9
 orjson>=2.4

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     packages=["drf_orjson_renderer"],
     license="MIT",
     install_requires=[
-        "django>=3.2,<=4.0",
+        "django>=3.2",
         "djangorestframework",
         "orjson>=3.3.0",
     ],


### PR DESCRIPTION
Instead of creating a periodic pull request for each minor Django version, perhaps only pinning the lower limit is a better tradeoff.


Related PRs
- https://github.com/brianjbuck/drf_orjson_renderer/pull/16
- https://github.com/brianjbuck/drf_orjson_renderer/pull/14