### PR TITLE
Parse media_type with q-factor weighting

### DIFF
--- a/drf_orjson_renderer/renderers.py
+++ b/drf_orjson_renderer/renderers.py
@@ -101,7 +101,7 @@ class ORJSONRenderer(BaseRenderer):
         # If `indent` is provided in the context, then pretty print the result.
         # E.g. If we're being called by RestFramework's BrowsableAPIRenderer.
         options = self.options
-        if media_type == self.html_media_type:
+        if media_type and self.html_media_type in media_type:
             options |= orjson.OPT_INDENT_2
 
         serialized: bytes = orjson.dumps(data, default=default, option=options)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -107,6 +107,12 @@ class RendererTestCase(unittest.TestCase):
 
         self.assertEqual(rendered.decode(), json.dumps(self.data, indent=2))
 
+        rendered = self.renderer.render(
+            data=self.data, media_type="text/html; q=1.0", renderer_context=None,
+        )
+
+        self.assertEqual(rendered.decode(), json.dumps(self.data, indent=2))
+
     def test_renderer_works_correctly_with_browsable_api_with_datetime(self):
         """
         When using the built-in json when called by the BrowsableAPIRenderer,


### PR DESCRIPTION
If there's q-factor weighting parameter in request header, the `media_type` would be like:
`text/html; q=1.0`
In this case, we still need to add indent when serializing the data.