### PR TITLE
Update setup.py since the lib doesn't support numpy 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "django>=3.2",
         "djangorestframework",
         "orjson>=3.3.0",
+        "numpy<2.0",
     ],
     python_requires=">=3.6.0",
     zip_safe=True,


### PR DESCRIPTION
the lib is causing AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64`